### PR TITLE
left aligning saved button

### DIFF
--- a/src/components/TipTapEditor.tsx
+++ b/src/components/TipTapEditor.tsx
@@ -52,7 +52,7 @@ export default ({note}: Props) =>
 
     return (
         <>
-            <div className="flex">
+            <div className="flex justify-start">
                 {editor && <TipTapMenuBar editor={editor}/> }
                 <Button disabled variant={"outline"}>
                     {saveNote.isPending ? 'Saving...' : 'Saved'}


### PR DESCRIPTION
Fixes #2

Align the saved button to the left.

* Add `justify-start` class to the `div` containing the saved button in `src/components/TipTapEditor.tsx`
* Ensure the button remains within the `div` with a `flex` class for horizontal alignment

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/danielbyiringiro/notes/pull/4?shareId=ef35936f-6956-4696-804a-1eb8d97e40fd).